### PR TITLE
修改为和微信朋友圈照片一样的模式，从底部往上初始滑动不触发拖动关闭模式。当图片在放大浏览时，滑动到顶部的时候也可以触发向下拖动关闭模式

### DIFF
--- a/library/src/main/java/cc/shinichi/library/view/helper/FingerDragHelper.java
+++ b/library/src/main/java/cc/shinichi/library/view/helper/FingerDragHelper.java
@@ -39,6 +39,7 @@ public class FingerDragHelper extends LinearLayout {
     private float mTranslationY;
     private float mLastTranslationY;
     private boolean isAnimate = false;
+    private boolean isFirstMoveAfterDown = true;
     private int mTouchslop;
     private onAlphaChangedListener mOnAlphaChangedListener;
 
@@ -73,6 +74,7 @@ public class FingerDragHelper extends LinearLayout {
         switch (action) {
             case MotionEvent.ACTION_DOWN:
                 mDownY = ev.getRawY();
+                isFirstMoveAfterDown = false;
             case MotionEvent.ACTION_MOVE:
                 if (ImagePreview.getInstance().isEnableDragClose()) {
                     if (imageGif != null && imageGif.getVisibility() == View.VISIBLE) {
@@ -91,6 +93,12 @@ public class FingerDragHelper extends LinearLayout {
                                     && Math.abs(ev.getRawY() - mDownY) > 2 * mTouchslop
                                     && imageView.atYEdge;
                         }
+                    }
+                    // 我的修改: 和微信表现一样：如果在放大模式并且不在顶部，滑动到顶部的时候这里可以拦截到事件
+                    // 此时mDownY应该重置为当前点，否则当前点离真正的按下点很远了直接view就被拖下来很远
+                    if (isIntercept && !isFirstMoveAfterDown) {
+                        mDownY = ev.getRawY();
+                        isFirstMoveAfterDown = true;
                     }
                 }
                 break;

--- a/library/src/main/java/cc/shinichi/library/view/helper/SubsamplingScaleImageViewDragClose.java
+++ b/library/src/main/java/cc/shinichi/library/view/helper/SubsamplingScaleImageViewDragClose.java
@@ -29,11 +29,6 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewParent;
 
-import androidx.annotation.AnyThread;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.exifinterface.media.ExifInterface;
-
 import com.davemorrissey.labs.subscaleview.ImageViewState;
 import com.davemorrissey.labs.subscaleview.R.styleable;
 import com.davemorrissey.labs.subscaleview.decoder.CompatDecoderFactory;
@@ -53,6 +48,12 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import androidx.annotation.AnyThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.exifinterface.media.ExifInterface;
+import cc.shinichi.library.ImagePreview;
 
 /**
  * @author 工藤
@@ -910,9 +911,12 @@ public class SubsamplingScaleImageViewDragClose extends View {
                             float lastY = vTranslate.y;
                             fitToBounds(true);
                             atXEdge = lastX != vTranslate.x;
-                            atYEdge = lastY != vTranslate.y;
+                            boolean enableUpDragClose = ImagePreview.getInstance().isEnableUpDragClose();
+                            // 我的修改: 只允许从上面往下关闭，不允许往上滑关闭. 如果Y在边缘并且是向上滑动，则判断为Y不在边缘
+                            atYEdge = (lastY != vTranslate.y) && (enableUpDragClose || ((event.getY() - vCenterStart.y) > 0));
                             boolean edgeXSwipe = atXEdge && dx > dy && !isPanning;
-                            boolean edgeYSwipe = atYEdge && dy > dx && !isPanning;
+                            // 我的修改：仿微信，即使正在移动图像，如果到了顶部，也允许往下滑动关闭, 即对Y移动不判断是否在panning
+                            boolean edgeYSwipe = atYEdge && dy > dx;// && !isPanning;
                             boolean yPan = lastY == vTranslate.y && dy > offset * 3;
                             if (!edgeXSwipe && !edgeYSwipe && (!atXEdge || !atYEdge || yPan || isPanning)) {
                                 isPanning = true;


### PR DESCRIPTION
修改文件为SubsamplingScaleImageViewDragClose和FingerDragHelper