### PR TITLE
fix：解决SubsamplingScaleImageViewDragClose中的742行空指针崩溃的问题

### DIFF
--- a/library/src/main/java/cc/shinichi/library/view/helper/SubsamplingScaleImageViewDragClose.java
+++ b/library/src/main/java/cc/shinichi/library/view/helper/SubsamplingScaleImageViewDragClose.java
@@ -241,7 +241,7 @@ public class SubsamplingScaleImageViewDragClose extends View {
     // Screen coordinate of top-left corner of source image
     private PointF vTranslate;
     private PointF vTranslateStart;
-    private PointF vTranslateBefore;
+    private PointF vTranslateBefore = new PointF(0, 0);
     // Source coordinate to center on, used when new position is set externally before view is ready
     private Float pendingScale;
     private PointF sPendingCenter;
@@ -517,7 +517,7 @@ public class SubsamplingScaleImageViewDragClose extends View {
         scaleStart = 0f;
         vTranslate = null;
         vTranslateStart = null;
-        vTranslateBefore = null;
+        vTranslateBefore.set(0, 0);
         pendingScale = 0f;
         sPendingCenter = null;
         sRequestedCenter = null;
@@ -729,9 +729,6 @@ public class SubsamplingScaleImageViewDragClose extends View {
 
         if (vTranslateStart == null) {
             vTranslateStart = new PointF(0, 0);
-        }
-        if (vTranslateBefore == null) {
-            vTranslateBefore = new PointF(0, 0);
         }
         if (vCenterStart == null) {
             vCenterStart = new PointF(0, 0);
@@ -1057,9 +1054,6 @@ public class SubsamplingScaleImageViewDragClose extends View {
         if (anim != null && anim.vFocusStart != null) {
             // Store current values so we can send an event if they change
             float scaleBefore = scale;
-            if (vTranslateBefore == null) {
-                vTranslateBefore = new PointF(0, 0);
-            }
             vTranslateBefore.set(vTranslate);
 
             long scaleElapsed = System.currentTimeMillis() - anim.time;

--- a/library/src/main/java/cc/shinichi/library/view/helper/SubsamplingScaleImageViewDragClose.java
+++ b/library/src/main/java/cc/shinichi/library/view/helper/SubsamplingScaleImageViewDragClose.java
@@ -713,7 +713,8 @@ public class SubsamplingScaleImageViewDragClose extends View {
         }
 
         // Abort if not ready
-        if (vTranslate == null) {
+        PointF translate = vTranslate;
+        if (translate == null) {
             if (singleDetector != null) {
                 singleDetector.onTouchEvent(event);
             }
@@ -736,7 +737,7 @@ public class SubsamplingScaleImageViewDragClose extends View {
 
         // Store current values so we can send an event if they change
         float scaleBefore = scale;
-        vTranslateBefore.set(vTranslate);
+        vTranslateBefore.set(translate);
 
         boolean handled = onTouchEventInternal(event);
         sendStateChanged(scaleBefore, vTranslateBefore, ORIGIN_TOUCH);


### PR DESCRIPTION
对应Issues：
Attempt to read from field 'float android.graphics.PointF.x' on a null object reference android.graphics.PointF.set(PointF.java:54)