### PR TITLE
FIX ：AVIF使用tilingDisabled标记，因为BitmapRegionDecoder不支持该格式。导致加载失败

### DIFF
--- a/library/src/main/java/cc/shinichi/library/tool/image/ImageUtil.kt
+++ b/library/src/main/java/cc/shinichi/library/tool/image/ImageUtil.kt
@@ -387,6 +387,12 @@ object ImageUtil {
             .endsWith("heic")
     }
 
+    fun isAvifImageWithMime(url: String, path: String): Boolean {
+        return "avif".equals(getImageTypeWithMime(path), ignoreCase = true)
+                || url.toLowerCase(Locale.CHINA).endsWith("avif") || url.toLowerCase(Locale.CHINA)
+            .endsWith("avif")
+    }
+
     fun isStaticImage(url: String, path: String): Boolean {
         val isWebpImageWithMime = isWebpImageWithMime(url, path)
         SLog.d(TAG, "isStaticImage: isWebpImageWithMime = $isWebpImageWithMime")
@@ -403,8 +409,10 @@ object ImageUtil {
         SLog.d(TAG, "isStaticImage: bmpImageWithMime = $bmpImageWithMime")
         val heifImageWithMime = isHeifImageWithMime(url, path)
         SLog.d(TAG, "isStaticImage: heifImageWithMime = $heifImageWithMime")
+        val avifImageWithMime = isAvifImageWithMime(url, path)
+        SLog.d(TAG, "isStaticImage: avifImageWithMime = $avifImageWithMime")
         val animImageWithMime = isAnimImageWithMime(url, path)
         SLog.d(TAG, "isStaticImage: animImageWithMime = $animImageWithMime")
-        return (jpegImageWithMime || pngImageWithMime || bmpImageWithMime || heifImageWithMime) && !animImageWithMime
+        return (jpegImageWithMime || pngImageWithMime || bmpImageWithMime || heifImageWithMime || avifImageWithMime) && !animImageWithMime
     }
 }

--- a/library/src/main/java/cc/shinichi/library/view/ImagePreviewFragment.kt
+++ b/library/src/main/java/cc/shinichi/library/view/ImagePreviewFragment.kt
@@ -474,7 +474,7 @@ class ImagePreviewFragment : Fragment() {
                         }
                         val widSmall = ImageUtil.getWidthHeight(smallImagePath)[0]
                         val heiSmall = ImageUtil.getWidthHeight(smallImagePath)[1]
-                        if (ImageUtil.isBmpImageWithMime(originalUrl, cacheFile.absolutePath)) {
+                        if (ImageUtil.isBmpImageWithMime(originalUrl, cacheFile.absolutePath) || ImageUtil.isAvifImageWithMime(originalUrl, cacheFile.absolutePath)) {
                             small?.tilingDisabled()
                         }
                         small?.dimensions(widSmall, heiSmall)
@@ -483,7 +483,7 @@ class ImagePreviewFragment : Fragment() {
                     val origin = ImageSource.uri(imagePath)
                     val widOrigin = ImageUtil.getWidthHeight(imagePath)[0]
                     val heiOrigin = ImageUtil.getWidthHeight(imagePath)[1]
-                    if (ImageUtil.isBmpImageWithMime(originalUrl, cacheFile.absolutePath)) {
+                    if (ImageUtil.isBmpImageWithMime(originalUrl, cacheFile.absolutePath) || ImageUtil.isAvifImageWithMime(originalUrl, cacheFile.absolutePath)) {
                         origin.tilingDisabled()
                     }
                     origin.dimensions(widOrigin, heiOrigin)
@@ -819,7 +819,7 @@ class ImagePreviewFragment : Fragment() {
         imageAnim.visibility = View.GONE
         imageStatic.visibility = View.VISIBLE
         val imageSource = ImageSource.uri(Uri.fromFile(File(imagePath)))
-        if (ImageUtil.isBmpImageWithMime(imagePath, imagePath)) {
+        if (ImageUtil.isBmpImageWithMime(imagePath, imagePath)  || ImageUtil.isAvifImageWithMime(imagePath, imagePath)) {
             imageSource.tilingDisabled()
         }
         imageStatic.setImage(imageSource)

--- a/library/src/main/java/cc/shinichi/library/view/ImagePreviewFragment.kt
+++ b/library/src/main/java/cc/shinichi/library/view/ImagePreviewFragment.kt
@@ -474,7 +474,7 @@ class ImagePreviewFragment : Fragment() {
                         }
                         val widSmall = ImageUtil.getWidthHeight(smallImagePath)[0]
                         val heiSmall = ImageUtil.getWidthHeight(smallImagePath)[1]
-                        if (ImageUtil.isBmpImageWithMime(originalUrl, cacheFile.absolutePath) || ImageUtil.isAvifImageWithMime(originalUrl, cacheFile.absolutePath)) {
+                        if (ImageUtil.isBmpImageWithMime(thumbnailUrl, smallImagePath) || ImageUtil.isAvifImageWithMime(thumbnailUrl, smallImagePath)) {
                             small?.tilingDisabled()
                         }
                         small?.dimensions(widSmall, heiSmall)
@@ -483,7 +483,7 @@ class ImagePreviewFragment : Fragment() {
                     val origin = ImageSource.uri(imagePath)
                     val widOrigin = ImageUtil.getWidthHeight(imagePath)[0]
                     val heiOrigin = ImageUtil.getWidthHeight(imagePath)[1]
-                    if (ImageUtil.isBmpImageWithMime(originalUrl, cacheFile.absolutePath) || ImageUtil.isAvifImageWithMime(originalUrl, cacheFile.absolutePath)) {
+                    if (ImageUtil.isBmpImageWithMime(originalUrl, imagePath) || ImageUtil.isAvifImageWithMime(originalUrl, imagePath)) {
                         origin.tilingDisabled()
                     }
                     origin.dimensions(widOrigin, heiOrigin)


### PR DESCRIPTION
Create a BitmapRegionDecoder from the specified byte array. Currently only the JPEG, PNG, WebP and HEIF formats are supported.